### PR TITLE
Query scopes, Server side sort

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -104,11 +104,12 @@ export class Search extends Component {
 
    onEnter(cm) {
        // if enter hit in query field, submit form
-       this.onQuery();
+       this.onQuery(this.state.text);
    }
    // when user hits query button
    onQuery(queryString) {
      const { dispatch } = this.props
+
      // get updated aggregations
      dispatch({
        type: 'REFRESH_QUERY',
@@ -117,6 +118,8 @@ export class Search extends Component {
        focus: this.props.focus,
        path: this.props.path,
        schema: this.props.schema,
+       currentQuery: this.props.currentQuery,
+       queryString: queryString,
      })
      this.triggerSearch();
    }
@@ -227,6 +230,7 @@ function mapStateToProps(state, own) {
            currentFacet: state.currentFacet,
            schema: state.schema,
            path: state.path,
+           currentQuery: state.currentQuery,
          };
 }
 export default connect(mapStateToProps) (Search);

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -30,6 +30,7 @@ export class Table extends Component {
   }
 
   handleRequestSort(property) {
+    //TODO - remove local sort once server returns sorted data
     const orderBy = property;
     let order = 'desc';
     if (this.state.orderBy === property && this.state.order === 'desc') {
@@ -38,7 +39,24 @@ export class Table extends Component {
     const data = this.props.data.sort(
       (a, b) => (order === 'desc' ? b[orderBy] > a[orderBy] : a[orderBy] > b[orderBy]),
     );
+
     this.setState({ data:data , order:order , orderBy:orderBy });
+    const { dispatch } = this.props
+    const cq = this.props.currentQuery;
+    const focus = this.props.label;
+    dispatch({
+      type: 'REFRESH_QUERY',
+      selectedFacets: cq[focus].selectedFacets,
+      label: focus,
+      focus: focus,
+      path: cq[focus].path,
+      schema: this.props.schema,
+      currentQuery: cq[focus].currentQuery,
+      queryString: cq[focus].queryString,
+      order:order,
+      orderBy:orderBy
+    })
+
   };
 
 
@@ -115,11 +133,12 @@ export class Table extends Component {
 function mapStateToProps(state, own) {
   console.log('Table mapStateToProps state',state)
   var data;
-  if(state.query && state.query[own.label] && !state.query[own.label].loading) {
-    data = state.query[own.label].results ? state.query[own.label].results.map(function(result) {return {...result.properties, gid: result.gid}}) : []
+  const currentQuery = state.currentQuery;
+  if(currentQuery && currentQuery[own.label] && !currentQuery[own.label].loading) {
+    data = currentQuery[own.label].results ? currentQuery[own.label].results.map(function(result) {return {...result.properties, gid: result.gid}}) : []
   }
   var loading = false;
-  if(state.query && state.query[own.label] && state.query[own.label].loading) {
+  if(currentQuery && currentQuery[own.label] && currentQuery[own.label].loading) {
     loading = true;
   }
 
@@ -134,6 +153,8 @@ function mapStateToProps(state, own) {
     data: data,
     facets: facets,
     loading: loading,
+    currentQuery: currentQuery,
+    schema: state.schema,
   }
 }
 

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -103,7 +103,7 @@ function followPaths(paths, edges, label) {
   var here = _.filter(edges, function(edge) {return edgeFor(edge, label)})
   var there = _.reject(edges, function(edge) {return edgeFor(edge, label)})
   console.log('here', here, 'there', there)
-  
+
   if (_.isEmpty(here)) {
     return [[label]]
   } else {
@@ -128,10 +128,10 @@ function followPaths(paths, edges, label) {
 
 function identity(i) {return i}
 
-function translateQuery(schema, visited, focus) {
+function translateQuery(schema, visited, focus, order, orderBy) {
   var nodes = nodesIn(schema, visited)
   var focal = nodes[focus]
-  console.log('translate query', focus, visited, focal, nodes)
+  console.log('translate query', focus, visited, focal, nodes, order, orderBy)
 
   if (focal) {
     var O = Ophion()
@@ -174,7 +174,7 @@ export default class Path {
     return ni(schema, path)
   }
 
-  static translateQuery(schema, visited, focus) {
-    return tq(schema, visited, focus)
+  static translateQuery(schema, visited, focus, order, orderBy) {
+    return tq(schema, visited, focus, order, orderBy)
   }
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,7 +3,7 @@ import { routerReducer } from 'react-router-redux';
 import { reducer as formReducer } from 'redux-form';
 import schema from './schema'
 import search from './search'
-import query from './query'
+import {query, queries, currentQuery} from './query'
 import path from './path'
 import FacetReducers from './facets'
 
@@ -18,4 +18,6 @@ export const reducers = combineReducers({
   facets: FacetReducers.facets,
   currentFacet: FacetReducers.currentFacet,
   query: query,
+  queries: queries,
+  currentQuery: currentQuery,
 });

--- a/src/reducers/query.js
+++ b/src/reducers/query.js
@@ -9,3 +9,21 @@ export default function query(state = {}, action) {
       return state
   }
 }
+
+export function queries(state = {}, action) {
+  switch (action.type) {
+    default:
+      return state
+  }
+}
+
+export function currentQuery(state = {name:'test'}, action) {
+  switch (action.type) {
+    case 'REFRESH_QUERY':
+      return {...state, [action.focus]: {queryString:action.queryString, selectedFacets:action.selectedFacets, order: action.order, orderBy: action.orderBy, loading:true} }
+    case 'QUERY_RESULTS_SAVE':
+      return {...state, [action.focus]: {...state[action.focus], path: action.path, focus: action.focus, results: action.results, loading:false}}
+    default:
+      return state
+  }
+}

--- a/src/sagas/query.js
+++ b/src/sagas/query.js
@@ -18,12 +18,13 @@ export function* pathQuery(action) {
   console.log('path query saga')
   console.log(action.path)
 
-  const query = Path.translateQuery(action.schema, action.path, action.focus).limit(10)
+  const query = Path.translateQuery(action.schema, action.path, action.focus, action.order, action.orderBy).limit(10)
   const results = yield OphionSearch.execute(query)
   yield put({
     type: 'QUERY_RESULTS_SAVE',
     path: action.path,
     focus: action.focus,
     results: results,
+    currentQuery: action.currentQuery,
   })
 }


### PR DESCRIPTION
This PR:
* moves query 'state' ( query string, selected facets, results, loading, etc) into a state variable `currentQuery`
* prepares redux plumbing for persisted `queries`
* adds `order` and `orderBy` parameters to 'REFRESH_QUERY'
* passes  `order` and `orderBy` to Path.translateQuery

Known issues:

* actual ophion sort is _not_ performed, //TODO - Ryan can you take a look at translateQuery?
translate query Gene [{…}] {label: "Gene", facets: {…}, edges: Array(7)} {Gene: {…}} `desc` `accession`
* No attempt yet to serialize queries, persist them or provide switch between them...
