### PR TITLE
material-ui.beta.5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cytoscape": "^3.1.4",
     "istanbul": "^0.4.5",
     "jsdom": "^10.1.0",
-    "material-ui": "1.0.0-beta.4",
+    "material-ui": "^1.0.0-beta.5",
     "material-ui-icons": "^1.0.0-alpha.19",
     "material-ui-search-bar": "^1.0.0-beta.2",
     "mui-icons": "^1.2.1",

--- a/src/components/Cohort.js
+++ b/src/components/Cohort.js
@@ -7,7 +7,8 @@ import * as _ from 'underscore'
 import SplitPane from 'react-flex-split-pane';
 import classnames from 'classnames';
 
-import { withStyles, createStyleSheet } from 'material-ui/styles';
+import { withStyles } from 'material-ui/styles';
+import { createMuiTheme } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import { CircularProgress } from 'material-ui/Progress';
 import Card, { CardContent, CardHeader, CardActions } from 'material-ui/Card';
@@ -309,14 +310,14 @@ function mapStateToProps(state, own) {
   }
 }
 
-
-const styleSheet = createStyleSheet(theme => ({
+const theme = createMuiTheme();
+const styles = {
   button: {
     margin: theme.spacing.unit,
   },
   input: {
     display: 'none',
   },
-}));
+};
 
-export default connect(mapStateToProps)(withStyles(styleSheet)(Cohort));
+export default connect(mapStateToProps)(withStyles(styles)(Cohort));

--- a/src/components/Facet.js
+++ b/src/components/Facet.js
@@ -6,7 +6,8 @@ import * as _ from 'underscore'
 
 
 import classnames from 'classnames';
-import { withStyles, createStyleSheet } from 'material-ui/styles';
+import { withStyles } from 'material-ui/styles';
+import { createMuiTheme } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Card, { CardContent } from 'material-ui/Card';
 import Collapse from 'material-ui/transitions/Collapse';
@@ -227,7 +228,8 @@ function mapStateToProps(state, own) {
   }
 }
 
-const styleSheet = createStyleSheet(theme => ({
+const theme = createMuiTheme();
+const styles = {
   card: {
     maxWidth: 400,
   },
@@ -243,6 +245,6 @@ const styleSheet = createStyleSheet(theme => ({
   flexGrow: {
     flex: '1 1 auto',
   },
-}));
+};
 
-export default connect(mapStateToProps)(withStyles(styleSheet)(Facet));
+export default connect(mapStateToProps)(withStyles(styles)(Facet));

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,7 +6,7 @@ import { push } from 'react-router-redux'
 import Search from './Search'
 
 
-import { withStyles, createStyleSheet } from 'material-ui/styles';
+import { withStyles } from 'material-ui/styles';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
@@ -115,7 +115,7 @@ export class Header extends Component {
   }
 }
 
-const styleSheet = createStyleSheet({
+const styles = {
   root: {
     marginTop: 4,
     width: '100%',
@@ -123,6 +123,6 @@ const styleSheet = createStyleSheet({
   flex: {
     flex: 1,
   },
-});
+};
 
-export default connect() (withStyles(styleSheet) (Header));
+export default connect() (withStyles(styles) (Header));

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -6,7 +6,8 @@ import * as _ from 'underscore'
 
 
 import PropTypes from 'prop-types';
-import { withStyles, createStyleSheet } from 'material-ui/styles';
+import { withStyles } from 'material-ui/styles';
+import { createMuiTheme } from 'material-ui/styles';
 import { CircularProgress } from 'material-ui/Progress';
 import ReactJson from 'react-json-view-callback'
 
@@ -137,7 +138,7 @@ export class Table extends Component {
                         {item[property_name]}
                     </TableCell>
                   );
-                })                 
+                })
               )
             }
           </TableRow>
@@ -215,13 +216,15 @@ function mapStateToProps(state, own) {
   }
 }
 
-const styleSheet = createStyleSheet(theme => ({
+
+const theme = createMuiTheme();
+const styles = {
   paper: {
     width: '100%',
     marginTop: theme.spacing.unit * 3,
     overflowX: 'auto',
   },
-}));
+};
 
 
-export default connect(mapStateToProps)(withStyles(styleSheet)(Table));
+export default connect(mapStateToProps)(withStyles(styles)(Table));


### PR DESCRIPTION
This PR has no new features. It upgrades to material-ui beta 5 and adjusts stylesheet calls to accomodate breaking api.