### PR TITLE
tag data directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
        - /mnt/data1/bmeg/mongo-data:/data/db
 
   grip:
-    image: bmeg/grip
+    # image: bmeg/grip
+    build: grip
     container_name: grip
     volumes:
         - ./secrets/grip_config.yml:/config/grip_config.yml
@@ -37,8 +38,8 @@ services:
       - ./nginx/bmeg-site/public:/usr/share/nginx/bmeg.io
       - ./nginx/usr/share/nginx/default:/usr/share/nginx/default
       - ./nginx/usr/share/nginx/gen3-ohsu.ddns.net:/usr/share/nginx/gen3-ohsu.ddns.net
-      - /mnt/data2/bmeg/bmeg-etl/outputs:/usr/share/nginx/bmegio.ohsu.edu.data
-      - /mnt/data2/bmeg/bmeg-etl/outputs:/usr/share/nginx/bmeg.io.data
+      - /mnt/data2/bmeg/bmeg-data:/usr/share/nginx/bmegio.ohsu.edu.data
+      - /mnt/data2/bmeg/bmeg-data:/usr/share/nginx/bmeg.io.data
 
       # config
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf

--- a/nginx/etc/nginx/sites-enabled/bmeg.io
+++ b/nginx/etc/nginx/sites-enabled/bmeg.io
@@ -20,7 +20,7 @@ server {
     try_files $uri $uri/index.html $uri.html =404;
   }
   # data
-  location /bmeg-data {
+  location /data {
     alias /usr/share/nginx/bmeg.io.data/; # directory to list
     autoindex on;
   }

--- a/nginx/etc/nginx/sites-enabled/bmegio.ohsu.edu
+++ b/nginx/etc/nginx/sites-enabled/bmegio.ohsu.edu
@@ -20,7 +20,7 @@ server {
     try_files $uri $uri/index.html $uri.html =404;
   }
   # data
-  location /bmeg-data {
+  location /data {
     alias /usr/share/nginx/bmegio.ohsu.edu.data/; # directory to list
     autoindex on;
   }


### PR DESCRIPTION
This PR:
* changes data directory to /mnt/data2/bmeg/bmeg-data
* changes path to directory to /data
Addresses #64 
(deployed on bmeg.io)
