### PR TITLE
Adds methylation.recount.bio

### DIFF
--- a/cycle_nginx.sh
+++ b/cycle_nginx.sh
@@ -1,0 +1,3 @@
+DC="docker-compose -f docker-compose.yml -f compose-services/docker-compose.yml  -f compose-services/onprem/docker-compose.yml"
+$DC exec nginx nginx -s reload
+echo `date` nginx reloaded

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - ./nginx/etc/nginx/sites-enabled/bmeg-jupyter.ddns.net:/etc/nginx/sites-enabled/bmeg-jupyter.ddns.net:ro
       - ./nginx/etc/nginx/sites-enabled/bmeg.io:/etc/nginx/sites-enabled/bmeg.io:ro
       - ./nginx/etc/nginx/sites-enabled/recount.bio:/etc/nginx/sites-enabled/recount.bio:ro
+      - ./nginx/etc/nginx/sites-enabled/methylation.recount.bio:/etc/nginx/sites-enabled/methylation.recount.bio:ro
 
       # testing
       - ./nginx/etc/nginx/sites-enabled/commons.bmeg.io:/etc/nginx/sites-enabled/commons.bmeg.io:ro

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -104,6 +104,7 @@ http {
 	include /etc/nginx/sites-enabled/gen3-ohsu.ddns.net;
 	include /etc/nginx/sites-enabled/bmeg-jupyter.ddns.net;
 	include /etc/nginx/sites-enabled/recount.bio;
+	include /etc/nginx/sites-enabled/methylation.recount.bio;
 	include /etc/nginx/sites-enabled/commons.bmeg.io;
 
 }

--- a/nginx/etc/nginx/sites-enabled/bmeg.io
+++ b/nginx/etc/nginx/sites-enabled/bmeg.io
@@ -33,6 +33,10 @@ server {
   location /.well-known/acme-challenge/ {
       root /var/www/certbot;
   }
+  # for bmeg-dash
+  location /app {
+      proxy_pass http://bmeg-dash:8050;
+  }
 
 	##
   # oath setup

--- a/nginx/etc/nginx/sites-enabled/commons.bmeg.io
+++ b/nginx/etc/nginx/sites-enabled/commons.bmeg.io
@@ -237,7 +237,7 @@ server {
 	  proxy_pass_header  REMOTE_USER;
 	  proxy_pass_header  REMOTE_ROLES;
 	  rewrite ^/tmp/(.*)$ /$1 break;
-	  proxy_pass http://tmp-service:3838/;
+	  # proxy_pass http://tmp-service:3838/;
 
 		# websocket headers
 		proxy_set_header Upgrade $http_upgrade;

--- a/nginx/etc/nginx/sites-enabled/methylation.recount.bio
+++ b/nginx/etc/nginx/sites-enabled/methylation.recount.bio
@@ -1,0 +1,26 @@
+# redirect to https
+server {
+	listen *:80;
+  server_name recount.bio;
+	return 302 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+
+  server_name methylation.recount.bio;
+  ssl_certificate /etc/letsencrypt/live/methylation.recount.bio/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/methylation.recount.bio/privkey.pem;
+
+  # data
+  location / {
+    alias /usr/share/nginx/recount.bio.data/; # directory to list
+    autoindex on;
+  }
+  # for certbot challenge
+  location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+  }
+
+}


### PR DESCRIPTION
Adds support for adding subdomain  `methylation.recount.bio`

To install:

```
# (apply these changes)
sudo  ./init-letsencrypt.sh  methylation.recount.bio
```
Note: it is assumed we will no longer host `recount.bio`, we will drop this site once domain has been moved.

  