### PR TITLE
Adds support for adding subdomain  `methylation.recount.bio`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ Notes:
 
 <img src="https://user-images.githubusercontent.com/47808/61067786-41d2ef00-a3bd-11e9-9ded-5d611dcb691c.png" alt="drawing" width="200"/>
 
+#### sync
+
+Notes: to sync from internal services -
+
+This crontab will sync daily at 00:00
+
+```
+0 0 * * * rsync --checksum  <source-directory>/*.*  <user@host>:<target-directory>
+```
+
 
 #### gen3 compose-services
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - ./nginx/etc/nginx/sites-enabled/bmeg-jupyter.ddns.net:/etc/nginx/sites-enabled/bmeg-jupyter.ddns.net:ro
       - ./nginx/etc/nginx/sites-enabled/bmeg.io:/etc/nginx/sites-enabled/bmeg.io:ro
       - ./nginx/etc/nginx/sites-enabled/recount.bio:/etc/nginx/sites-enabled/recount.bio:ro
+      - ./nginx/etc/nginx/sites-enabled/methylation.recount.bio:/etc/nginx/sites-enabled/methylation.recount.bio:ro
 
       # testing
       - ./nginx/etc/nginx/sites-enabled/commons.bmeg.io:/etc/nginx/sites-enabled/commons.bmeg.io:ro

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -104,6 +104,7 @@ http {
 	include /etc/nginx/sites-enabled/gen3-ohsu.ddns.net;
 	include /etc/nginx/sites-enabled/bmeg-jupyter.ddns.net;
 	include /etc/nginx/sites-enabled/recount.bio;
+	include /etc/nginx/sites-enabled/methylation.recount.bio;
 	include /etc/nginx/sites-enabled/commons.bmeg.io;
 
 }

--- a/nginx/etc/nginx/sites-enabled/methylation.recount.bio
+++ b/nginx/etc/nginx/sites-enabled/methylation.recount.bio
@@ -1,0 +1,26 @@
+# redirect to https
+server {
+	listen *:80;
+  server_name recount.bio;
+	return 302 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+
+  server_name methylation.recount.bio;
+  ssl_certificate /etc/letsencrypt/live/methylation.recount.bio/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/methylation.recount.bio/privkey.pem;
+
+  # data
+  location / {
+    alias /usr/share/nginx/recount.bio.data/; # directory to list
+    autoindex on;
+  }
+  # for certbot challenge
+  location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+  }
+
+}


### PR DESCRIPTION
Adds support for adding subdomain  `methylation.recount.bio`

To install:

```
# (apply these changes)
sudo  ./init-letsencrypt.sh  methylation.recount.bio
```
Note: it is assumed we will no longer host `recount.bio`, we will drop this site once domain has been moved.

  