### PR TITLE
Adds TLS 1.2 and strict header

### DIFF
--- a/nginx/etc/nginx/sites-enabled/bmeg.io
+++ b/nginx/etc/nginx/sites-enabled/bmeg.io
@@ -10,9 +10,13 @@ server {
   listen 443 ssl http2;
   listen [::]:443 ssl http2;
 
+
   server_name bmeg.io;
   ssl_certificate /etc/letsencrypt/live/bmeg.io/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/bmeg.io/privkey.pem;
+
+  ssl_protocols TLSv1.2;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   # content
   location / {

--- a/nginx/etc/nginx/sites-enabled/bmegio.ohsu.edu
+++ b/nginx/etc/nginx/sites-enabled/bmegio.ohsu.edu
@@ -13,6 +13,8 @@ server {
   server_name bmegio.ohsu.edu;
   ssl_certificate /etc/letsencrypt/live/bmegio.ohsu.edu/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/bmegio.ohsu.edu/privkey.pem;
+  ssl_protocols TLSv1.2;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   # content
   location / {

--- a/nginx/etc/nginx/sites-enabled/methylation.recount.bio
+++ b/nginx/etc/nginx/sites-enabled/methylation.recount.bio
@@ -1,7 +1,7 @@
 # redirect to https
 server {
 	listen *:80;
-  server_name recount.bio;
+  	server_name methylation.recount.bio;
 	return 302 https://$host$request_uri;
 }
 
@@ -12,6 +12,9 @@ server {
   server_name methylation.recount.bio;
   ssl_certificate /etc/letsencrypt/live/methylation.recount.bio/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/methylation.recount.bio/privkey.pem;
+
+  ssl_protocols TLSv1.2;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   # data
   location / {

--- a/nginx/etc/nginx/sites-enabled/recount.bio
+++ b/nginx/etc/nginx/sites-enabled/recount.bio
@@ -1,7 +1,7 @@
 # redirect to https
 server {
 	listen *:80;
-  server_name recount.bio;
+  	server_name recount.bio;
 	return 302 https://$host$request_uri;
 }
 
@@ -12,6 +12,9 @@ server {
   server_name recount.bio;
   ssl_certificate /etc/letsencrypt/live/recount.bio/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/recount.bio/privkey.pem;
+
+  ssl_protocols TLSv1.2;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   # content
   location / {


### PR DESCRIPTION
Based on feedback from itg



104743 | TLS Version 1.0 Protocol Detection | Service detection | Medium | 137.53.238.130 | TCP | 443
-- | -- | -- | -- | -- | -- | --
121010 | TLS Version 1.1 Protocol Detection | Service detection | Medium | 137.53.238.130 | TCP | 443
142960 | HSTS Missing From HTTPS Server (RFC 6797) | Web Servers | Medium | 137.53.238.130 | TCP | 443


servers now respond with

```
$ curl -svo /dev/null  --compressed  https://bmeg.io 2>&1 | grep strict
< strict-transport-security: max-age=31536000; includeSubDomains
$ curl -s  -vvvv https://bmeg.io  2>&1 | grep "SSL connection using"
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
 
$ curl -svo /dev/null  --compressed  https://bmegio.ohsu.edu 2>&1 | grep strict
< strict-transport-security: max-age=31536000; includeSubDomains
curl -svo /dev/null  --compressed  https://bmegio.ohsu.edu  2>&1 | grep "SSL connection using"
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305

$ curl -svo /dev/null  --compressed  https://methylation.recount.bio  2>&1 | grep "SSL connection using"
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
$ curl -svo /dev/null  --compressed  https://methylation.recount.bio  2>&1 | grep strict
< strict-transport-security: max-age=31536000; includeSubDomains```